### PR TITLE
Support for Django 1.3

### DIFF
--- a/dj_elastictranscoder/urls.py
+++ b/dj_elastictranscoder/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls import url, patterns
+try:
+    from django.conf.urls import url, patterns
+except ImportError:
+    from django.conf.urls.defaults import url, patterns  # Support for Django < 1.4
 
 urlpatterns = patterns('dj_elastictranscoder.views',
     url(r'^endpoint/$', 'endpoint'),

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires = [
-        "django >= 1.4",
+        "django >= 1.3",
         "boto >= 2.5",
         "South >= 0.8",
     ],


### PR DESCRIPTION
This patch will lower the minimum supported Django version to 1.3, by modifying `urls.py` to import from `django.conf.urls.defaults` if `django.conf.urls` does not have `url` and `patterns`.

As someone who is stuck at 1.3 :cry:, this is a very trivial but also very useful change.