### PR TITLE
Python3 Compatability in Views

### DIFF
--- a/dj_elastictranscoder/tests.py
+++ b/dj_elastictranscoder/tests.py
@@ -70,8 +70,7 @@ class SNSNotificationTest(TestCase):
             content = f.read()
 
         resp = self.client.post('/endpoint/', content, content_type="application/json")
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.content, 'Done')
+        self.assertContains(resp, 'Done', status_code=200)
 
         job = EncodeJob.objects.get(id=self.job_id)
         self.assertEqual(job.state, 1)
@@ -81,8 +80,7 @@ class SNSNotificationTest(TestCase):
             content = f.read()
 
         resp = self.client.post('/endpoint/', content, content_type="application/json")
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.content, 'Done')
+        self.assertContains(resp, 'Done', status_code=200)
 
         job = EncodeJob.objects.get(id=self.job_id)
         self.assertEqual(job.state, 2)
@@ -93,8 +91,7 @@ class SNSNotificationTest(TestCase):
             content = f.read()
 
         resp = self.client.post('/endpoint/', content, content_type="application/json")
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.content, 'Done')
+        self.assertContains(resp, 'Done', status_code=200)
 
         job = EncodeJob.objects.get(id=self.job_id)
         self.assertEqual(job.state, 4)

--- a/dj_elastictranscoder/views.py
+++ b/dj_elastictranscoder/views.py
@@ -18,7 +18,7 @@ def endpoint(request):
     """
 
     try:
-        data = json.loads(request.read())
+        data = json.loads(request.read().decode('utf-8'))
     except ValueError:
         return HttpResponseBadRequest('Invalid JSON')
 


### PR DESCRIPTION
This solves an error in Python 3:
```
TypeError: the JSON object must be str, not 'bytes'
```
and remains backwards compatible with Python2.x.