### PR TITLE
Referencing object with id breaks

### DIFF
--- a/dj_elastictranscoder/transcoder.py
+++ b/dj_elastictranscoder/transcoder.py
@@ -53,5 +53,5 @@ class Transcoder(object):
         job = EncodeJob()
         job.id = self.message['Job']['Id']
         job.content_type = content_type
-        job.object_id = obj.id
+        job.object_id = obj.pk
         job.save()


### PR DESCRIPTION
The `create_job_for_object` method was breaking for any objects that do not use `id` as the primary key. Simple fix was to use `pk` instead.