### PR TITLE
Fixed django warning

### DIFF
--- a/dj_elastictranscoder/models.py
+++ b/dj_elastictranscoder/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 import django
-if django.get_version() > '1.8':
+if django.get_version() >= '1.8':
     from django.contrib.contenttypes.fields import GenericForeignKey
 else:
     from django.contrib.contenttypes.generic import GenericForeignKey


### PR DESCRIPTION
Django was still throwing the Removed in Django 1.9 warning for the `GenericForeignKey` import in the models, if your django version was exactly 1.8. Changing the version check to be `>=` fixes it.