### PR TITLE
Adding missing migration.

### DIFF
--- a/dj_elastictranscoder/migrations/0002_auto_20160120_1923.py
+++ b/dj_elastictranscoder/migrations/0002_auto_20160120_1923.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dj_elastictranscoder', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='encodejob',
+            name='state',
+            field=models.PositiveIntegerField(choices=[(0, 'Submitted'), (1, 'Progressing'), (2, 'Error'), (3, 'Warning'), (4, 'Complete')], db_index=True, default=0),
+        ),
+    ]


### PR DESCRIPTION
Reopened this merge request with the changes on a separate branch.

When running make migrations for my project I noticed that an additional migration was being created for this app. The only difference that I saw between this migration and the initial migration is that the initial migration uses byte strings for the choices.

Looking at the history for the models file it doesn't look like the state choices were ever byte strings. It looks like they were added to the migration when the migrations were changed to be compatible with Django 1.8.
