### PR TITLE
Fix the issue when "messageDetails" is not present in the error response

### DIFF
--- a/dj_elastictranscoder/views.py
+++ b/dj_elastictranscoder/views.py
@@ -58,7 +58,15 @@ def endpoint(request):
         transcode_oncomplete.send(sender=None, job=job, message=message)
     elif message['state'] == 'ERROR':
         job = EncodeJob.objects.get(pk=message['jobId'])
-        job.message = message['messageDetails']
+        
+        error_message = 'messageDetails' in message and message['messageDetails'] or ''
+        # when you convert HLS there is no messageDetails, but there are list of segemnts and statusDetail for each item
+        if not error_message and 'outputs' in message and len(message['outputs']):
+            # let's find first segment with error response
+            error_segment = next((i for i in message['outputs'] if i['status'] == 'Error'), None)
+            error_message = error_segment and error_segment['statusDetail'] or 'Error'
+
+        job.message = error_message
         job.state = 2
         job.save()
 


### PR DESCRIPTION
When "messageDetails" is not available (for example when we convert HLS), we need to find segment error and store it
