### PR TITLE
Get Django version from django.VERSION

### DIFF
--- a/dj_elastictranscoder/models.py
+++ b/dj_elastictranscoder/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from django.contrib.contenttypes.models import ContentType
 
 import django
-if django.get_version() >= '1.8':
+if django.VERSION >= (1, 8):
     from django.contrib.contenttypes.fields import GenericForeignKey
 else:
     from django.contrib.contenttypes.generic import GenericForeignKey

--- a/dj_elastictranscoder/urls.py
+++ b/dj_elastictranscoder/urls.py
@@ -1,7 +1,7 @@
 import django
 
 
-if django.get_version() >= '1.9':
+if django.VERSION >= (1, 9):
     from django.conf.urls import url
     from dj_elastictranscoder import views
 


### PR DESCRIPTION
Get Django version from `django.VERSION`.
`django.get_version()` is not working in Django 1.10 since either `'1.10 > '1.8'` or `'1.10 > '1.9'` is `False`.