### PR TITLE
docs: fix simple typo, receieve -> receive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Setting Up AWS SNS endpoint
 
 AWS Elastic Transcoder can send various SNS notification to notify your application, like ``PROGRESS``, ``ERROR``, ``WARNING`` and ``COMPLETE``
 
-So this package provide a endpoint to receieve these notifications, for you to update transcode progress. without checking by your self.
+So this package provide a endpoint to receive these notifications, for you to update transcode progress. without checking by your self.
 
 Go to SNS section in AWS WebConsole to choose topic and subscribe with the url below.
 


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `receive` rather than `receieve`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md